### PR TITLE
Also check yum (Centos) or dnf (Fedora) for system package tool

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -182,22 +182,18 @@ class FFMpegConan(ConanFile):
 
     def system_requirements(self):
         if self.settings.os == "Linux" and tools.os_info.is_linux:
-            package_tool = tools.SystemPackageTool(conanfile=self, default_mode="verify")
+            package_tool = tools.SystemPackageTool()
             packages = []
             if tools.os_info.with_apt:
                 if self.options.vaapi:
-                    if not package_tool.installed('libva-dev'):
-                        packages.append('libva-dev')
+                    packages.append('libva-dev')
                 if self.options.vdpau:
-                    if not package_tool.installed('libvdpau-dev'):
-                        packages.append('libvdpau-dev')
+                    packages.append('libvdpau-dev')
             elif tools.os_info.with_yum or tools.os_info.with_dnf:
                 if self.options.vaapi:
-                    if not package_tool.installed('libva-devel'):
-                        packages.append('libva-devel')
+                    packages.append('libva-devel')
                 if self.options.vdpau:
-                    if not package_tool.installed('libvdpau-devel'):
-                        packages.append('libvdpau-devel')
+                    packages.append('libvdpau-devel')
             for package in packages:
                 package_tool.install(package)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -182,16 +182,24 @@ class FFMpegConan(ConanFile):
 
     def system_requirements(self):
         if self.settings.os == "Linux" and tools.os_info.is_linux:
+            package_tool = tools.SystemPackageTool(conanfile=self, default_mode="verify")
+            packages = []
             if tools.os_info.with_apt:
-                installer = tools.SystemPackageTool()
-
-                packages = []
                 if self.options.vaapi:
-                    packages.append('libva-dev')
+                    if not package_tool.installed('libva-dev'):
+                        packages.append('libva-dev')
                 if self.options.vdpau:
-                    packages.append('libvdpau-dev')
-                for package in packages:
-                    installer.install(package)
+                    if not package_tool.installed('libvdpau-dev'):
+                        packages.append('libvdpau-dev')
+            elif tools.os_info.with_yum or tools.os_info.with_dnf:
+                if self.options.vaapi:
+                    if not package_tool.installed('libva-devel'):
+                        packages.append('libva-devel')
+                if self.options.vdpau:
+                    if not package_tool.installed('libvdpau-devel'):
+                        packages.append('libvdpau-devel')
+            for package in packages:
+                package_tool.install(package)
 
     def _copy_pkg_config(self, name):
         root = self.deps_cpp_info[name].rootpath


### PR DESCRIPTION
I followed the current trend in packages to set `SystemPackageTool`'s  `default_mode` to "verify" as opposed to have it enabled by default. Please let me know if you prefer I remove this (so that packages are installed by default if `CONAN_SYSREQUIRES_MODE` is not set). Also I am not sure if the `installed` checks actually do anything or not. Let me know if it's better to remove those.